### PR TITLE
[README] correct the unzipped directory name in 'how to use' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Decide of a new library name, let's say `new-super-library` (🤦🏼‍♀️),
 curl --output rollup-jest-boilerplate.zip -LOk https://github.com/algolia/rollup-jest-boilerplate/archive/master.zip
 unzip rollup-jest-boilerplate.zip
 rm rollup-jest-boilerplate.zip
-mv rollup-jest-boilerplate new-super-library
+mv rollup-jest-boilerplate-master new-super-library
 ```
 
 **Next steps:**


### PR DESCRIPTION
The directory name inside the zip file differs from directory name described in the README file.

![pullrequest_rollup](https://user-images.githubusercontent.com/10475327/47483161-ce8e4a80-d838-11e8-8e67-576172aa1960.png)
